### PR TITLE
Implement Github Actions CI for Cloudflare build

### DIFF
--- a/.github/workflows/cloudflare-ci.yaml
+++ b/.github/workflows/cloudflare-ci.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 23.5
+    - name: Use Node.js version of Cloudflare
       uses: actions/setup-node@v5
       with:
-        node-version: '23.5.0'
+        node-version: '22.16.0'
     - name: Install deps and build
       run: |
         npm install


### PR DESCRIPTION
Uses the same node version with cloudflare, which is 22.16.0. We will implement restriction for node version in package.json later