### PR TITLE
Fix dependencies and node versions for better reproducibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Please take a look at our documentation to get started.
 - [Deployment to Vercel](./documentation/deployment.md)
 - [Rolling Out Updates](./documentation/updates.md)
 
+# Update in node depenndency 
+
+We have updated the dependency versions. If you face any version trouble best form is to rebuild using steps bellow . 
+    delete node_modules folder
+    delete package-lock.json
+    run npm cache verify
+    run npm install
 
 
 # example-app-router

--- a/package.json
+++ b/package.json
@@ -8,11 +8,15 @@
     "start": "next start",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
-    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
+    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
+    "postinstall": "patch-package"
+  },
+  "engines": {
+    "node": "^22.16.0"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
-    "@opennextjs/cloudflare": "^1.6.5",
+    "@opennextjs/cloudflare": "1.6.5",
     "@portabletext/react": "^3.2.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-checkbox": "^1.3.2",
@@ -42,12 +46,13 @@
     "gray-matter": "^4.0.3",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.539.0",
-    "next": "^15.4.6",
+    "next": "15.4.6",
     "next-intl": "^4.3.4",
     "next-sanity": "^10.0.10",
     "next-themes": "^0.4.6",
     "nodemailer": "^7.0.5",
     "npm-check-updates": "^18.0.2",
+    "patch-package": "^8.0.0",
     "posthog-js": "^1.259.0",
     "posthog-node": "^5.6.0",
     "react": "^19.1.1",

--- a/patches/@opennextjs+cloudflare+1.6.5.patch
+++ b/patches/@opennextjs+cloudflare+1.6.5.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/@opennextjs/cloudflare/dist/cli/commands/utils.js b/node_modules/@opennextjs/cloudflare/dist/cli/commands/utils.js
+index 562ba80..d232437 100644
+--- a/node_modules/@opennextjs/cloudflare/dist/cli/commands/utils.js
++++ b/node_modules/@opennextjs/cloudflare/dist/cli/commands/utils.js
+@@ -7,6 +7,7 @@ import { printHeader, showWarningOnWindows } from "@opennextjs/aws/build/utils.j
+ import logger from "@opennextjs/aws/logger.js";
+ import { unstable_readConfig } from "wrangler";
+ import { createOpenNextConfigIfNotExistent, ensureCloudflareConfig } from "../build/utils/index.js";
++import { pathToFileURL } from "node:url";
+ export const nextAppDir = process.cwd();
+ /**
+  * Print headers and warnings for the CLI.
+@@ -39,7 +40,8 @@ export async function retrieveCompiledConfig() {
+         logger.error("Could not find compiled Open Next config, did you run the build command?");
+         process.exit(1);
+     }
+-    const config = await import(configPath).then((mod) => mod.default);
++    // const config = await import(configPath).then((mod) => mod.default);
++    const config = await import(pathToFileURL(configPath).href).then((mod) => mod.default);
+     ensureCloudflareConfig(config);
+     return { config };
+ }


### PR DESCRIPTION
Node version is the same as the version running on Cloudflare The opennextjs/cloudflare package has a dynamic path parsing issue on windows that breaks the preview command. A patch through patch-package has been created and it will be installed through npm install.

### After pulling, do this once:
- delete node_modules folder
- delete package-lock.json
- run ```npm cache verify```
- run ```npm install```

# Before making a pull request ALWAYS run ```npm run preview``` to verify your code builds and deploys before clogging the CI.