### PR TITLE
Implement support for underline and numbered lists

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -168,6 +168,9 @@ const portableTextComponents = {
     em: ({children}: any) => (
       <em className="italic text-gray-800">{children}</em>
     ),
+    underline: ({children}: any) => (
+      <u className="underline decoration-2 underline-offset-2">{children}</u>
+    ),
     code: ({children}: any) => (
       <code className="bg-gray-100 text-[#C61E1E] px-2 py-1 rounded text-base font-mono border">
         {children}

--- a/src/sanity/schemaTypes/blockContentType.ts
+++ b/src/sanity/schemaTypes/blockContentType.ts
@@ -31,7 +31,7 @@ export const blockContentType = defineType({
         {title: 'H4', value: 'h4'},
         {title: 'Quote', value: 'blockquote'},
       ],
-      lists: [{title: 'Bullet', value: 'bullet'}],
+      lists: [{title: 'Bullet', value: 'bullet'}, {title: 'Numbered', value: 'number'}],
       // Marks let you mark up inline text in the Portable Text Editor
       marks: {
         // Decorators usually describe a single property – e.g. a typographic
@@ -39,6 +39,7 @@ export const blockContentType = defineType({
         decorators: [
           {title: 'Strong', value: 'strong'},
           {title: 'Emphasis', value: 'em'},
+          {title: 'Underline', value: 'underline'}
         ],
         // Annotations can be any object structure – e.g. a link or a footnote.
         annotations: [


### PR DESCRIPTION
Underlines and numbered lists were required by the new blog post, so the Sanity schema now includes the two, numbered lists were customized already on the frontend but custom underline rendering for underlines have been added.

