### PR TITLE
Display author's name only

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -20,10 +20,7 @@ interface BlogPost {
   title: string;
   slug: string;
   publishedAt: string;
-  author?: {
-    name: string;
-    image?: any;
-  };
+  author?: string; // Currently just the author's name, add more fields if needed
   excerpt?: string;
   readTime?: number;
   body: any[]; // PortableText array
@@ -227,10 +224,8 @@ export default async function BlogPostPage(props: BlogPostPageProps) {
     },
     author: post.author
       ? {
-          ...post.author,
-          imageUrl: post.author.image
-            ? urlFor(post.author.image).width(48).height(48).url()
-            : undefined
+          name: post.author,
+          imageUrl: undefined
         }
       : undefined
   };

--- a/src/components/blog/BlogSidebar.tsx
+++ b/src/components/blog/BlogSidebar.tsx
@@ -59,7 +59,7 @@ export function BlogSidebar({post}: BlogSidebarProps) {
               )}
               <div>
                 <p className="font-medium text-gray-900">{post.author.name}</p>
-                <p className="text-sm text-gray-600">Turkish Club Munich</p>
+                {/* <p className="text-sm text-gray-600">Turkish Club Munich</p> */}
               </div>
             </div>
           </div>

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -24,10 +24,7 @@ export const POST_QUERY =
     },
     alt
   },
-  author->{
-    name,
-    image
-  },
+  author,
   categories[]->{
     title,
     "slug": slug.current


### PR DESCRIPTION
On Sanity we only store the name per post, therefore it does not make sense as it is to render images or display hardcoded affliations as one of our blog post is written by a guest writer.